### PR TITLE
Remove bash-ism from commit filter

### DIFF
--- a/run-filter-branch
+++ b/run-filter-branch
@@ -9,7 +9,7 @@ git update-index --index-info'
 # SC2016: Expressions don't expand in single quotes, use double quotes for that.
 # shellcheck disable=SC2016
 commit_filter='tmp=$(git_commit_non_empty_tree "$@");
-[[ $GIT_COMMIT = $tmp ]] || echo >&7 $GIT_COMMIT $tmp;
+test "$GIT_COMMIT" = "$tmp" || echo >&7 "$GIT_COMMIT $tmp";
 echo $tmp'
 
 : "${RFWORK_DIR:=$PWD}"


### PR DESCRIPTION
This slipped through because this has previously only been tested on
systems where git filter-branch has used bash, either explicitly or
implicitly because the system default shell is bash-like.
